### PR TITLE
Improve IAM scanner logging and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Johndcyber IAM Resource Scanner is a Python script designed to detect overly
 ## Features
 
 - Scans all IAM policies in your AWS account.
+- Scans both managed and inline IAM role policies.
 - Identifies overly permissive policies (e.g., policies with `*` actions or resources).
 - Lists roles attached to the identified policies.
 - Describes the type of access (read or write) granted by the policies.
@@ -34,10 +35,10 @@ The Johndcyber IAM Resource Scanner is a Python script designed to detect overly
 
 2. Run the script using Python:
     \`\`\`bash
-    python johndcyber_iam_scanner.py
+    python johndcyber_iam_scanner.py [--debug]
     \`\`\`
 
-3. The script will log its progress and any errors encountered to both the console and a log file named `johndcyber_iam_scanner.log`.
+3. The script will log its progress and any errors encountered to both the console and a log file named `johndcyber_iam_scanner.log`. Use the `--debug` flag for verbose output.
 
 4. The results will be written to a CSV file named `overly_permissive_policies.csv` with the following columns:
     - `Resource`: Roles attached to the overly permissive policy.


### PR DESCRIPTION
## Summary
- scan both managed and inline IAM role policies
- support `--debug` flag for verbose logging
- add functions to retrieve roles and their inline policies
- exclude read-only actions more accurately
- update README with new usage and feature notes

## Testing
- `python -m py_compile johndcyber_iam_scanner.py`
- `flake8 johndcyber_iam_scanner.py` *(fails: E501 line too long)*
- `python johndcyber_iam_scanner.py --help`
- `python johndcyber_iam_scanner.py --debug` *(fails: NoCredentialsError)*

------
https://chatgpt.com/codex/tasks/task_b_68464ffefe088330904e436bca0db647